### PR TITLE
fix url encoding

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -128,8 +128,10 @@ class CustomCollector:
                 return
 
             project, repository = repo['name'].split("/", maxsplit=1)
+            repository = repository.replace("/library", "")
             # this is needed for getting repos like proxy.docker.io/bitnami/nginx
             repository_patched = requests.utils.quote(repository, safe="")
+            repository_patched = requests.utils.quote(repository_patched, safe="")
             url = f'{HARBOR_API_URL}/projects/{project}/repositories/{repository_patched}/artifacts'
             response = requests.get(url, params=URL_PARAMS, auth=AUTH)
             response.raise_for_status()


### PR DESCRIPTION
<!-- Describe the purpose of the PR -->
## What does this change resolve?

As per the documentation of the Harbor API you need to double escape characters. Without this it gave a 404 error on matching urls. Also `/library` shouldn't be there either.

## Open questions or TODOs before merging if any
None
