### PR TITLE
patch CVEs in base image and urllib3 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.13-alpine
 
+RUN apk upgrade --no-cache
+
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY exporter.py /usr/local/bin/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prometheus-client==0.21.0
 requests==2.32.3
+urllib3>=2.6.0
 flake8==7.1.1


### PR DESCRIPTION
- 🔒 Add apk upgrade to patch Alpine OS CVEs (CVE-2024-12797, CVE-2025-26519, CVE-2025-3277, CVE-2025-6965, CVE-2025-29087, CVE-2025-31115)
- 🔒 Pin urllib3>=2.6.0 to fix CVE-2025-66418 and CVE-2025-66471
- 🧹 Add --no-cache-dir to pip install to reduce image size